### PR TITLE
fix compilation example 'menu_mcol'

### DIFF
--- a/examples/menu_mcol/mcolmenu.go
+++ b/examples/menu_mcol/mcolmenu.go
@@ -64,7 +64,7 @@ func main() {
 
 	menu.SetWindow(menuwin)
 	dwin := menuwin.Derived(6, 38, 3, 1)
-	menu.SubWindow(&dwin)
+	menu.SubWindow(dwin)
 	menu.Option(gc.O_SHOWDESC, true)
 	menu.Format(5, 3)
 	menu.Mark(" * ")


### PR DESCRIPTION
Hi.

This is fix for error:
```
./mcolmenu.go:67: cannot use &dwin (type **goncurses.Window) as type *goncurses.Window in argument to menu.SubWindow
```