### PR TITLE
readme update for osx users

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ the "extended" curses functionality found in the form and menu extentions.
 For installation instructions, please see the
 [wiki](https://github.com/rthornton128/goncurses/wiki/WindowsInstallation).
 
+OSX Users
+---------
+For installation instructions, please refer
+[here](http://mrcook.uk/how-to-install-go-ncurses-on-mac-osx).
+
+
 Notes
 -----
 


### PR DESCRIPTION
Hi, I had some trouble on osx since it seems like ncurses 6.0 does not include the .pc files needed here, such as ncurses.pc, form.pc, etc.

Following the linked blog fixed this issue by creating the missing .pc files and setting the PKG_CONFIG_PATH flag.