### PR TITLE
Add build support for Mac OSX and OpenBSD

### DIFF
--- a/defs.go
+++ b/defs.go
@@ -4,7 +4,7 @@
 
 package goncurses
 
-// #cgo !windows pkg-config: ncurses
+// #cgo !darwin,!openbsd,!windows pkg-config: ncurses
 // #include <curses.h>
 import "C"
 

--- a/form.go
+++ b/form.go
@@ -6,7 +6,8 @@
 
 package goncurses
 
-// #cgo pkg-config: form
+// #cgo !darwin,!openbsd pkg-config: form
+// #cgo darwin openbsd LDFLAGS: -lform
 // #include <form.h>
 // #include <stdlib.h>
 import "C"

--- a/goncurses.c
+++ b/goncurses.c
@@ -57,7 +57,7 @@ bool ncurses_is_keypad(const WINDOW *win) {
 }
 
 bool ncurses_is_pad(const WINDOW *win) {
-#ifdef PDCURSES
+#if defined(PDCURSES) || NCURSES_VERSION_MAJOR < 6
 	return false; /* no known built-in way to test for this */
 #else
 	return is_pad(win);
@@ -67,8 +67,10 @@ bool ncurses_is_pad(const WINDOW *win) {
 bool ncurses_is_subwin(const WINDOW *win) {
 #ifdef PDCURSES
 	return win->_parent != NULL;
-#else
+#elseif NCURSES_VERSION_MAJOR > 5
 	return is_subwin(win);
+#else
+	return false; /* FIXME */
 #endif
 }
 

--- a/menu.go
+++ b/menu.go
@@ -7,7 +7,8 @@
 package goncurses
 
 /*
-#cgo pkg-config: menu
+#cgo !darwin,!openbsd pkg-config: menu
+#cgo darwin openbsd LDFLAGS: -lmenu
 #include <menu.h>
 #include <stdlib.h>
 

--- a/mouse.go
+++ b/mouse.go
@@ -5,7 +5,7 @@
 
 package goncurses
 
-// #cgo !windows pkg-config: ncurses
+// #cgo !darwin,!openbsd,!windows pkg-config: ncurses
 // #cgo windows CFLAGS: -DNCURSES_MOUSE_VERSION
 // #cgo windows LDFLAGS: -lpdcurses
 // #include <curses.h>

--- a/ncurses.go
+++ b/ncurses.go
@@ -5,9 +5,10 @@
 
 package goncurses
 
-// #cgo !windows pkg-config: ncurses
+// #cgo !darwin,!openbsd,!windows pkg-config: ncurses
 // #cgo windows CFLAGS: -DNCURSES_MOUSE_VERSION
 // #cgo windows LDFLAGS: -lpdcurses
+// #cgo darwin openbsd LDFLAGS: -lncurses
 // #include <curses.h>
 // #include "goncurses.h"
 import "C"

--- a/panel.go
+++ b/panel.go
@@ -4,7 +4,8 @@
 
 package goncurses
 
-// #cgo !windows pkg-config: panel
+// #cgo !darwin,!openbsd,!windows pkg-config: panel
+// #cgo darwin openbsd LDFLAGS: -lpanel
 // #include <panel.h>
 // #include <curses.h>
 import "C"


### PR DESCRIPTION
Hi! This PR adds native build support for both Mac OSX and OpenBSD (and any other UNIXes with system installed ncurses can just follow along).
One small issue: since both of these operating systems still have ncurses 5.8, I wasn't able to find a good substitute for the `is_subwin(win)` function though.