### PR TITLE
Add COLORS and COLOR_PAIRS export

### DIFF
--- a/defs.go
+++ b/defs.go
@@ -102,6 +102,14 @@ const (
 	C_YELLOW        = C.COLOR_YELLOW
 )
 
+// COLORS defines the maximum number of colors the terminal supports
+// and COLOR_PAIRS defintes the maximum number of color pairs the
+// terminal supports
+const (
+	COLORS      = C.COLORS
+	COLOR_PAIRS = C.COLOR_PAIRS
+)
+
 type Key int
 
 const (


### PR DESCRIPTION
As defined in 'man 3 color_pair', the COLORS and COLOR_PAIRS global
variables define the maximum number of colors and color pairs the
terminal can support.  This commit exports those variables to goncurses
for use in determining the number of colors/color pairs the terminal
supports.
