### PR TITLE
fix menu header hline off by one

### DIFF
--- a/examples/menu_subwin/submenu.go
+++ b/examples/menu_subwin/submenu.go
@@ -49,8 +49,8 @@ func main() {
 	menuwin.MovePrint(1, (x/2)-(len(title)/2), title)
 	menuwin.ColorOff(1)
 	menuwin.MoveAddChar(2, 0, gc.ACS_LTEE)
-	menuwin.HLine(2, 1, gc.ACS_HLINE, x-3)
-	menuwin.MoveAddChar(2, x-2, gc.ACS_RTEE)
+	menuwin.HLine(2, 1, gc.ACS_HLINE, x-2)
+	menuwin.MoveAddChar(2, x-1, gc.ACS_RTEE)
 
 	y, x = stdscr.MaxYX()
 	stdscr.MovePrint(y-2, 1, "'q' to exit")


### PR DESCRIPTION
The menu separator RTEE was off by one in the submenu example.

Before:
![image](https://cloud.githubusercontent.com/assets/208392/17117915/71f705e8-528c-11e6-961c-073425200cd0.png)

After:
![image](https://cloud.githubusercontent.com/assets/208392/17117927/7c55a666-528c-11e6-9ae5-868abbd831b0.png)
