### PR TITLE
Fix minor typos in documentation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -32,6 +32,6 @@
 // concurrently. Failure to do so will result in unpredictable and
 // undefined behaviour in your program.
 //
-// The examples directory contains demontrations of many of the capabilities
+// The examples directory contains demonstrations of many of the capabilities
 // goncurses can provide.
 package goncurses

--- a/examples/concurrency/concur.go
+++ b/examples/concurrency/concur.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file.
 
 // This example demonstrates using goncurses with Go's built-in concurrency
-// primatives. It is key to ensure no reads or writes occur concurrently to
+// primitives. It is key to ensure no reads or writes occur concurrently to
 // a window or screen. Another method would be to use a global mutex.
 package main
 
@@ -40,10 +40,10 @@ func main() {
 	}(scr, in)
 
 	// Once a character has been received on the 'in' channel the
-	// 'ready' channel will block until it recieves another piece of data.
+	// 'ready' channel will block until it receives another piece of data.
 	// This happens only once the received character has been written to
 	// the screen. The 'in' channel then blocks on the next loop until
-	// another 'true' is sent down the 'ready' channel signalling to the
+	// another 'true' is sent down the 'ready' channel signaling to the
 	// input goroutine that it's okay to receive input
 	for {
 		var c gc.Char

--- a/examples/getstr/getstr.go
+++ b/examples/getstr/getstr.go
@@ -24,8 +24,8 @@ func main() {
 	row, col = (row/2)-1, (col-len(msg))/2
 	stdscr.MovePrint(row, col, msg)
 
-	/* GetString will only retieve the specified number of characters. Any
-	attempts by the user to enter more characters will elicit an audiable
+	/* GetString will only retrieve the specified number of characters. Any
+	attempts by the user to enter more characters will elicit an audible
 	beep */
 	var str string
 	str, err = stdscr.GetString(10)

--- a/examples/hello/hello.go
+++ b/examples/hello/hello.go
@@ -20,7 +20,7 @@ func main() {
 	}
 	defer goncurses.End()
 
-	// (Go)ncurses draws by cursor position and uses reverse cartisian
+	// (Go)ncurses draws by cursor position and uses reverse Cartesian
 	// coordinate system (y,x). Initially, the cursor is positioned at the
 	// coordinates 0,0 so the first call to Print will output the text at the
 	// top, left position of the screen since stdscr is a window which

--- a/ext_defs.go
+++ b/ext_defs.go
@@ -114,7 +114,7 @@ const (
 	O_ONEVALUE   = C.O_ONEVALUE   // Only one item can be selected
 	O_SHOWDESC   = C.O_SHOWDESC   // Display item descriptions
 	O_ROWMAJOR   = C.O_ROWMAJOR   // Display in row-major order
-	O_IGNORECASE = C.O_IGNORECASE // Ingore case when pattern-matching
+	O_IGNORECASE = C.O_IGNORECASE // Ignore case when pattern-matching
 	O_SHOWMATCH  = C.O_SHOWMATCH  // Move cursor to item when pattern-matching
 	O_NONCYCLIC  = C.O_NONCYCLIC  // Don't wrap next/prev item
 )

--- a/form.go
+++ b/form.go
@@ -64,7 +64,7 @@ func (f *Field) Free() error {
 }
 
 // Info retrieves the height, width, y, x, offset and buffer size of the
-// given field. Pass the memory addess of the variable to store the data
+// given field. Pass the memory address of the variable to store the data
 // in or nil.
 func (f *Field) Info(h, w, y, x, off, nbuf *int) error {
 	err := C.field_info((*C.FIELD)(f), (*C.int)(unsafe.Pointer(h)),
@@ -182,7 +182,7 @@ func (f *Form) Driver(drvract Key) error {
 
 // Free the memory allocated to the form. Forms are not automatically
 // free'd by Go's garbage collection system so the memory allocated to
-// it must be explicitely free'd
+// it must be explicitly free'd
 func (f *Form) Free() error {
 	err := C.free_form(f.form)
 	f = nil
@@ -226,7 +226,7 @@ func (f *Form) SetWindow(w *Window) error {
 	return ncursesError(syscall.Errno(err))
 }
 
-// Sub returns the subwindow assocaiated with the form
+// Sub returns the subwindow associated with the form
 func (f *Form) Sub() Window {
 	return Window{C.form_sub(f.form)}
 }

--- a/menu.go
+++ b/menu.go
@@ -79,7 +79,7 @@ func (m *Menu) Current(mi *MenuItem) *MenuItem {
 }
 
 // Driver controls how the menu is activated. Action usually corresponds
-// to the string return by the Key() function in goncurses.
+// to the string returned by the Key() function in goncurses.
 func (m *Menu) Driver(daction int) error {
 	err := C.menu_driver(m.menu, C.int(daction))
 	return ncursesError(syscall.Errno(err))
@@ -208,8 +208,8 @@ func (m *Menu) SetPattern(pattern string) error {
 	return ncursesError(syscall.Errno(err))
 }
 
-// SetSpacing of the the menu's items. 'desc' is the space between the
-// item and it's description andmay not be larger than TAB_SIZE. 'row'
+// SetSpacing of the menu's items. 'desc' is the space between the
+// item and it's description and may not be larger than TAB_SIZE. 'row'
 // is the number of rows separating each item and may not be larger than
 // three. 'col' is the spacing between each column of items in
 // multi-column mode. Use values of 0 or 1 to reset spacing to default,

--- a/ncurses.go
+++ b/ncurses.go
@@ -190,7 +190,7 @@ func IsTermResized(nlines, ncols int) bool {
 	return bool(C.is_term_resized(C.int(nlines), C.int(ncols)))
 }
 
-// Returns a string representing the value of input returned by Getch
+// Returns a string representing the value of input returned by GetChar
 func KeyString(k Key) string {
 	key, ok := keyList[k]
 	if !ok {
@@ -277,7 +277,7 @@ func Update() error {
 
 // UseDefaultColors tells the curses library to assign the terminal's default
 // foreground and background colors to color number -1. This will allow you to
-// call InitPair(x, -1, -1) to set both the foreground and backgroun colours
+// call InitPair(x, -1, -1) to set both the foreground and background colours
 // of pair x to the terminal's default. This function can fail if the terminal
 // does not support certain ncurses features like orig_pair or initialize_pair.
 func UseDefaultColors() error {

--- a/pad.go
+++ b/pad.go
@@ -16,7 +16,7 @@ type Pad struct {
 }
 
 // NewPad creates a window which is not restricted by the terminal's
-// dimentions (unlike a Window). Pads accept all functions which can be
+// dimensions (unlike a Window). Pads accept all functions which can be
 // called on a window. It returns a pointer to a new Pad of h(eight) by
 // w(idth).
 func NewPad(h, w int) (*Pad, error) {
@@ -28,7 +28,7 @@ func NewPad(h, w int) (*Pad, error) {
 }
 
 // NoutRefresh indicates that a section of the screen should be redrawn but
-// does not update the phsyical screen until Update() is called. See
+// does not update the physical screen until Update() is called. See
 // Pad.Refresh() for details on the arguments and Window.NoutRefresh for
 // more details on the workings of this function
 func (p *Pad) NoutRefresh(py, px, sy, sx, h, w int) error {
@@ -45,7 +45,7 @@ func (p *Pad) NoutRefresh(py, px, sy, sx, h, w int) error {
 // The coordinates py, px specify the location on the pad from which the
 // characters we want to display are located. sy and sx specify the location
 // on the screen where this data should be displayed. h and w are the height
-// and width of the rectangle to be displayed. The coodinates and the size
+// and width of the rectangle to be displayed. The coordinates and the size
 // of the rectangle must be contained within both the Pad's and Window's
 // respective areas
 func (p *Pad) Refresh(py, px, sy, sx, h, w int) error {

--- a/panel.go
+++ b/panel.go
@@ -18,7 +18,7 @@ type Panel struct {
 
 // Panel creates a new panel derived from the window, adding it to the
 // panel stack. The pointer to the original window can still be used to
-// excute most window functions with the exception of Refresh(). Always
+// execute most window functions with the exception of Refresh(). Always
 // use panel's Refresh() function.
 func NewPanel(w *Window) *Panel {
 	return &Panel{C.new_panel(w.win)}

--- a/screen.go
+++ b/screen.go
@@ -27,7 +27,7 @@ type Screen struct{ scrPtr *C.SCREEN }
 // call End() in reverse order that each terminal was created in. After you
 // are finished with the screen you must call Delete to free the memory
 // allocated to it. This function is usually only useful for programs using
-// multiple terminals or test for terminal capabilites. The argument termType
+// multiple terminals or test for terminal capabilities. The argument termType
 // is the type of terminal to be used ($TERM is used if value is "" which also
 // has the same effect of using os.Getenv("TERM"))
 func NewTerm(termType string, out, in *os.File) (*Screen, error) {

--- a/slk.go
+++ b/slk.go
@@ -127,7 +127,7 @@ func SlkAttributeOn(attr Char) error {
 	return nil
 }
 
-// SlkAttributeOff turns off the given OR'd attributes withoiut turning any on
+// SlkAttributeOff turns off the given OR'd attributes without turning any on
 func SlkAttributeOff(attr Char) error {
 	if C.slk_attroff(C.chtype(attr)) == C.ERR {
 		return errors.New("Soft-keys or terminal not initialized.")

--- a/window.go
+++ b/window.go
@@ -136,7 +136,7 @@ func (w *Window) ClearToEOL() error {
 	return nil
 }
 
-// Color sets the forground/background color pair for the entire window
+// Color sets the foreground/background color pair for the entire window
 func (w *Window) Color(pair int16) {
 	C.wcolor_set(w.win, C.short(ColorPair(pair)), nil)
 }
@@ -150,7 +150,7 @@ func (w *Window) ColorOff(pair int16) error {
 }
 
 // Normally color pairs are turned on via attron() in ncurses but this
-// implementation chose to make it seperate
+// implementation chose to make it separate
 func (w *Window) ColorOn(pair int16) error {
 	if C.ncurses_wattron(w.win, C.int(ColorPair(pair))) == C.ERR {
 		return errors.New("Failed to enable color pair")
@@ -185,7 +185,7 @@ func (w *Window) DelChar() error {
 	return nil
 }
 
-// MoveDelChar deletes the character at the givin cursor coordinates, moving all
+// MoveDelChar deletes the character at the given cursor coordinates, moving all
 // characters to the right of that position one space to the left and appends
 // a blank character at the end.
 func (w *Window) MoveDelChar(y, x int) error {
@@ -234,7 +234,7 @@ func (w *Window) Erase() {
 }
 
 // GetChar retrieves a character from standard input stream and returns it.
-// In the event of an error or if the input timeout has expired (ie. if
+// In the event of an error or if the input timeout has expired (i.e. if
 // Timeout() has been set to zero or a positive value and no characters have
 // been received) the value returned will be zero (0)
 func (w *Window) GetChar() Key {
@@ -261,8 +261,8 @@ func (w *Window) GetString(n int) (string, error) {
 	return C.GoString(&cstr[0]), nil
 }
 
-// Getyx returns the current cursor location in the Window. Note that it uses
-// ncurses idiom of returning y then x.
+// CursorYX returns the current cursor location in the Window. Note that it
+// uses ncurses idiom of returning y then x.
 func (w *Window) CursorYX() (int, int) {
 	var cy, cx C.int
 	C.ncurses_getyx(w.win, &cy, &cx)
@@ -382,7 +382,7 @@ func (w *Window) Print(args ...interface{}) {
 	w.Printf("%s", fmt.Sprint(args...))
 }
 
-// Printf functions the same as the stardard library's fmt package. See Print
+// Printf functions the same as the standard library's fmt package. See Print
 // for more details.
 func (w *Window) Printf(format string, args ...interface{}) {
 	cstr := C.CString(fmt.Sprintf(format, args...))
@@ -391,7 +391,7 @@ func (w *Window) Printf(format string, args ...interface{}) {
 	C.waddstr(w.win, cstr)
 }
 
-// Println behaves the s as Println in the stanard library's fmt package.
+// Println behaves the same as the standard library's fmt package.
 // See Print for more information.
 func (w *Window) Println(args ...interface{}) {
 	w.Printf("%s", fmt.Sprintln(args...))
@@ -485,7 +485,7 @@ func (w *Window) Sync(sync int) {
 
 // Timeout sets the window to blocking or non-blocking read mode. Calls to
 // GetCh will behave in the following manor depending on the value of delay:
-// <= -1 - blocking mode is set (blocks indefinately)
+// <= -1 - blocking mode is set (blocks indefinitely)
 // ==  0 - non-blocking; returns zero (0)
 // >=  1 - blocks for delay in milliseconds; returns zero (0)
 func (w *Window) Timeout(delay int) {
@@ -521,7 +521,7 @@ func (w *Window) UnTouch() {
 	C.ncurses_untouchwin(w.win)
 }
 
-// VLine draws a verticle line starting at y, x and ending at height using
+// VLine draws a vertical line starting at y, x and ending at height using
 // the specified character
 func (w *Window) VLine(y, x int, ch Char, wid int) {
 	C.mvwvline(w.win, C.int(y), C.int(x), C.chtype(ch), C.int(wid))


### PR DESCRIPTION
Just a few minor things I noticed while reading the documentation and examples, which are both excellent. Thank you for this great package; it made writing Curses in Go very pleasant.