### PR TITLE
Add TabSizeGet and TabSizeSet APIs

### DIFF
--- a/ncurses.go
+++ b/ncurses.go
@@ -307,3 +307,14 @@ func UseDefaultColors() error {
 func UseEnvironment(use bool) {
 	C.use_env(C.bool(use))
 }
+
+// SetTabSize allows for modification of the tab width. This setting is global
+// and affects all windows.
+func SetTabSize(tabSize int) {
+	C.TABSIZE = C.int(tabSize)
+}
+
+// TabSize returns the configured tab width.
+func TabSize() int {
+	return int(C.TABSIZE)
+}


### PR DESCRIPTION
TabSizeGet and TabSizeSet is a pair of APIs allowing the modification of
the ncurses' global variable TABSIZE. TABSIZE defines the tab width of
the \t character.