### PR TITLE
Fix menu driver arg type

### DIFF
--- a/ext_defs.go
+++ b/ext_defs.go
@@ -91,22 +91,22 @@ type MenuDriverReq C.int
 
 const (
 	REQ_LEFT          MenuDriverReq = C.REQ_LEFT_ITEM
-	REQ_RIGHT                       = C.REQ_RIGHT_ITEM
-	REQ_UP                          = C.REQ_UP_ITEM
-	REQ_DOWN                        = C.REQ_DOWN_ITEM
-	REQ_ULINE                       = C.REQ_SCR_ULINE
-	REQ_DLINE                       = C.REQ_SCR_DLINE
-	REQ_PAGE_DOWN                   = C.REQ_SCR_DPAGE
-	REQ_PAGE_UP                     = C.REQ_SCR_UPAGE
-	REQ_FIRST                       = C.REQ_FIRST_ITEM
-	REQ_LAST                        = C.REQ_LAST_ITEM
-	REQ_NEXT                        = C.REQ_NEXT_ITEM
-	REQ_PREV                        = C.REQ_PREV_ITEM
-	REQ_TOGGLE                      = C.REQ_TOGGLE_ITEM
-	REQ_CLEAR_PATTERN               = C.REQ_CLEAR_PATTERN
-	REQ_BACK_PATTERN                = C.REQ_BACK_PATTERN
-	REQ_NEXT_MATCH                  = C.REQ_NEXT_MATCH
-	REQ_PREV_MATCH                  = C.REQ_PREV_MATCH
+	REQ_RIGHT         MenuDriverReq = C.REQ_RIGHT_ITEM
+	REQ_UP            MenuDriverReq = C.REQ_UP_ITEM
+	REQ_DOWN          MenuDriverReq = C.REQ_DOWN_ITEM
+	REQ_ULINE         MenuDriverReq = C.REQ_SCR_ULINE
+	REQ_DLINE         MenuDriverReq = C.REQ_SCR_DLINE
+	REQ_PAGE_DOWN     MenuDriverReq = C.REQ_SCR_DPAGE
+	REQ_PAGE_UP       MenuDriverReq = C.REQ_SCR_UPAGE
+	REQ_FIRST         MenuDriverReq = C.REQ_FIRST_ITEM
+	REQ_LAST          MenuDriverReq = C.REQ_LAST_ITEM
+	REQ_NEXT          MenuDriverReq = C.REQ_NEXT_ITEM
+	REQ_PREV          MenuDriverReq = C.REQ_PREV_ITEM
+	REQ_TOGGLE        MenuDriverReq = C.REQ_TOGGLE_ITEM
+	REQ_CLEAR_PATTERN MenuDriverReq = C.REQ_CLEAR_PATTERN
+	REQ_BACK_PATTERN  MenuDriverReq = C.REQ_BACK_PATTERN
+	REQ_NEXT_MATCH    MenuDriverReq = C.REQ_NEXT_MATCH
+	REQ_PREV_MATCH    MenuDriverReq = C.REQ_PREV_MATCH
 )
 
 // Menu Options

--- a/menu.go
+++ b/menu.go
@@ -80,7 +80,7 @@ func (m *Menu) Current(mi *MenuItem) *MenuItem {
 
 // Driver controls how the menu is activated. Action usually corresponds
 // to the string returned by the Key() function in goncurses.
-func (m *Menu) Driver(daction int) error {
+func (m *Menu) Driver(daction MenuDriverReq) error {
 	err := C.menu_driver(m.menu, C.int(daction))
 	return ncursesError(syscall.Errno(err))
 }


### PR DESCRIPTION
Setting the type of the value in a `const` only propagates its type when using `iota`. When manually setting each value, the type needs to be explicitly specified. This  means the `MenuDriverReq` type only applied to `REQ_LEFT` and none of the other constants.

Additionally, the menu driver method took in a generic integer value. This allowed any of the menu driver options to be passed in except `REQ_LEFT`. It should accept only valid menu request values.

Fixes #53 