### PR TITLE
Change param names and update documentation

### DIFF
--- a/examples/pad/pad.go
+++ b/examples/pad/pad.go
@@ -34,11 +34,18 @@ func main() {
 	// Refresh the pad to show only a portion of the pad. Understanding
 	// what these coordinates mean can be a bit tricky. The first two
 	// coordinates are the position in the pad, in this case 0,5 (remember
-	// the coordinates in ncurses are y,x). The second set of numbers are the
-	// coordinates on the screen on which to display the content, so row 5,
-	// column 10. The last set of numbers tell how high and how wide the
-	// rectangle to displayed should be, in this case 15 rows long and 25
-	// columns wide.
+	// the coordinates in ncurses are y,x). The next four set of numbers
+	// are the coordinates of the pad on the screen (y1, x1, y2, x2):
+	//
+	//   (y1,x1) +-------------+
+	//           |             |
+	//           |             |
+	//           |             |
+	//           |             |
+	//           |             |
+	//           |             |
+	//           +-------------+ (y2, x2)
+	//
 	pad.Refresh(0, 5, 5, 10, 15, 25)
 	pad.GetChar()
 }

--- a/pad.go
+++ b/pad.go
@@ -43,14 +43,25 @@ func (p *Pad) NoutRefresh(py, px, sy, sx, h, w int) error {
 // Refresh will calculate how to update the physical screen in the most
 // efficient manor and update it. See Window.Refresh for more details.
 // The coordinates py, px specify the location on the pad from which the
-// characters we want to display are located. sy and sx specify the location
-// on the screen where this data should be displayed. h and w are the height
-// and width of the rectangle to be displayed. The coordinates and the size
-// of the rectangle must be contained within both the Pad's and Window's
-// respective areas
-func (p *Pad) Refresh(py, px, sy, sx, h, w int) error {
-	if C.prefresh(p.win, C.int(py), C.int(px), C.int(sy), C.int(sx),
-		C.int(h), C.int(w)) != C.OK {
+// characters we want to display are located. sy1 and sx1 specify the location
+// on the screen where this data should be displayed, hence the upper left
+// corner of the display area on the screen. sy2 and sx2 specify the location
+// of the lower right corner of the display area on the screen:
+//
+//   (y1,x1) +-------------+
+//           |             |
+//           |             |
+//           |             |
+//           |             |
+//           |             |
+//           |             |
+//           +-------------+ (y2, x2)
+//
+// The coordinates of the rectangle must be contained within both the Pad's
+// and Window's respective areas.
+func (p *Pad) Refresh(py, px, sy1, sx1, sy2, sx2 int) error {
+	if C.prefresh(p.win, C.int(py), C.int(px), C.int(sy1), C.int(sx1),
+		C.int(sy2), C.int(sx2)) != C.OK {
 		return errors.New("Failed to refresh pad")
 	}
 	return nil


### PR DESCRIPTION
Hi,

in my tests the parameters of the Refresh Pad call must be different from the documentation:

When I change the parameters in the call to `Refresh` in `examples/pad.go` to

```go
	pad.Refresh(0, 5, 5, 10, 1, 25)
```

(if I got the documentation right it would just show one row in height from the upper left coordinates with these parameters) no content is displayed.

I assume the last two parameters should be the coordinates of the lower right corner of the pad on the screen as documented here: https://de.wikibooks.org/wiki/Ncurses:_Pads (sorry for the german content).

I have updated the documentation and parameter names to reflect that.

Please let me know what you think :slightly_smiling_face: 