### PR TITLE
map DriverActions from Key to MenuDriverReq to fix examples

### DIFF
--- a/ext.go
+++ b/ext.go
@@ -18,7 +18,7 @@ import (
 
 // DriverActions is a convenience mapping for common responses
 // to keyboard input
-var DriverActions = map[Key]int{
+var DriverActions = map[Key]MenuDriverReq{
 	KEY_DOWN:     C.REQ_DOWN_ITEM,
 	KEY_HOME:     C.REQ_FIRST_ITEM,
 	KEY_END:      C.REQ_LAST_ITEM,


### PR DESCRIPTION
Fixes https://github.com/rthornton128/goncurses/issues/67

### Tests

- [x] Verified all the examples run (except newterm) - go version go1.18.3 linux/amd64